### PR TITLE
chore(deps): consolidate dependency updates for v0.2.482

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4687,9 +4687,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7495,9 +7495,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Consolidates the open Dependabot PRs into a single release branch and bumps the version to `0.2.482`.

### Superseded updates

| PR | Update |
|----|--------|
| #39 | chore(deps-dev): bump undici from 7.28.0 to 7.29.0 |
| #38 | chore(deps): bump ip-address from 10.2.0 to 10.4.0 |

### Verification

- `npm ci` clean install ✅
- `npm run build` — VitePress client + server bundles, page render and sitemap all succeed ✅
- `npm audit` (prod) reports 0 vulnerabilities ✅
- `ip-address` resolves to 10.4.0, `undici` to 7.29.0 ✅

`package.json` carries no `version` field here, so the branch is named from the latest release tag (`v0.2.481` → `v0.2.482`).
