### PR TITLE
chore(deps): bump postcss to 8.5.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "glob": "13.0.6",
         "jsdom": "28.1.0",
         "vitepress": "^1.6.3"
-      }
+      },
+      "version": ""
     },
     "node_modules/@acemir/cssom": {
       "version": "0.9.31",
@@ -6138,9 +6139,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -8173,5 +8174,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     }
-  }
+  },
+  "version": ""
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   "overrides": {
     "esbuild": "^0.25.0",
     "tmp": "^0.2.4"
-  }
+  },
+  "version": ""
 }


### PR DESCRIPTION
Consolidates the open Dependabot PR(s).

Supersedes #41.

### Verification

`npm run build` succeeds (VitePress, full multi-locale docs tree).